### PR TITLE
fix: serve TS modules with correct MIME

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -5,6 +5,8 @@
   },
   "mimeTypes": {
     ".js": "text/javascript",
+    ".ts": "text/javascript",
+    ".tsx": "text/javascript",
     ".css": "text/css"
   }
 }


### PR DESCRIPTION
## Summary
- serve `.ts` and `.tsx` files with a JavaScript MIME type so module scripts load correctly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a72f729e3083279a39bd353842731f