### PR TITLE
docs: explain env setup and common warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,16 @@ npm --prefix web install   # Install frontend dependencies
 
 The API will be available at http://127.0.0.1:8000/healthz.
 The frontend will be available at http://127.0.0.1:5173/.
+
+## Configuration
+
+Copy the sample environment file and provide the required secrets:
+
+```bash
+cp .env.example .env
+# then edit .env and set API_KEY, MSAL_CLIENT_ID, MSAL_TENANT_ID
+```
+
+Without these values, the frontend logs messages such as
+`API_KEY environment variable not set. AI features will be disabled.` and
+`MSAL configuration not found or incomplete from backend. Microsoft login will be disabled.`

--- a/web/README.md
+++ b/web/README.md
@@ -120,3 +120,10 @@ This repository includes a `staticwebapp.config.json` file. This is the official
 ### Production Environment Variables
 
 In the Azure Portal, navigate to your Static Web App resource and go to **Configuration**. Add your `API_KEY`, `MSAL_CLIENT_ID`, and `MSAL_TENANT_ID` as **Application settings**. These will be securely provided to your application at runtime.
+
+## Troubleshooting
+
+- **AI features disabled**: If the browser console logs `API_KEY environment variable not set. AI features will be disabled.`,
+  ensure `API_KEY` is defined in your `.env` file.
+- **Microsoft login disabled**: A warning `MSAL configuration not found or incomplete from backend. Microsoft login will be disabled.`
+  indicates that `MSAL_CLIENT_ID` or `MSAL_TENANT_ID` is missing.


### PR DESCRIPTION
## Summary
- document required env vars for frontend configuration
- add troubleshooting notes for missing API key or MSAL config

## Testing
- `pytest`
- `npm --prefix web run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac47d071988327a28a5c93465b2dbd